### PR TITLE
Filename change when Saving

### DIFF
--- a/PROTOTYPE7/src/js/RealTimeDrawer.js
+++ b/PROTOTYPE7/src/js/RealTimeDrawer.js
@@ -139,13 +139,19 @@ RealTimeDrawer.prototype.enable_disable_Drawing = function () {
 }
 
 RealTimeDrawer.prototype.saveDrawing = function () {
+    var filenameWithExtension = this.viewer.data[0].url.split('/').pop(); // "visiblehuman.nii.gz"
+    var filenameWithoutExtension = filenameWithExtension.split('.').shift(); // "visiblehuman"
+
+
     //this.nv.saveImage("draw.nii", true);
-    this.nv.saveDocument("niivue.drawing.nvd");
-    return;
+    this.nv.saveDocument(filenameWithoutExtension + ".drawing.nvd");
 };
 
 RealTimeDrawer.prototype.saveScreenshot = function () {
-    this.nv.saveScene("niivue.png")
+    var filenameWithExtension = this.viewer.data[0].url.split('/').pop(); // "visiblehuman.nii.gz"
+    var filenameWithoutExtension = filenameWithExtension.split('.').shift(); // "visiblehuman"
+
+    this.nv.saveScene(filenameWithoutExtension + ".png")
 };
 
 RealTimeDrawer.prototype.draw = function () {


### PR DESCRIPTION
The name of the file when saving it as a .nvd or .png should now be the same as the file that was uploaded.